### PR TITLE
Relax `base` version bounds and bump to 0.3.0.2

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-8.6
+resolver: lts-9.10
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/tld.cabal
+++ b/tld.cabal
@@ -10,7 +10,7 @@ name:                tld
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.3.0.1
+version:             0.3.0.2
 
 -- A short (one-line) description of the package.
 synopsis:            This project separates subdomains, domains, and top-level-domains from URLs. 
@@ -58,8 +58,8 @@ library
   -- other-extensions:    
   
   -- Other library packages from which modules are imported.
-  build-depends:       
-                         base >=4.7 && <4.10
+  build-depends:
+                         base ==4.*
                        , containers
                        , network-uri
                        , text


### PR DESCRIPTION
Tested w/ `lts-9.10` & `nightly-2017-10-02`